### PR TITLE
Fix MetricsApiResponse export

### DIFF
--- a/app/types/metricsApiResponse.d.ts
+++ b/app/types/metricsApiResponse.d.ts
@@ -1,7 +1,7 @@
 import type { CopilotMetrics } from "@/model/Copilot_Metrics";
 import type { Metrics } from "@/model/Metrics";
 
-interface MetricsApiResponse {
-    metrics: Metrics[]; // Replace `any` with the actual type of metrics
-    usage: CopilotMetrics[];   // Replace `any` with the actual type of usage
+export interface MetricsApiResponse {
+    metrics: Metrics[];
+    usage: CopilotMetrics[];
 }


### PR DESCRIPTION
## Summary
- export `MetricsApiResponse` in `metricsApiResponse.d.ts`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471376e8bc8323b530b8d350f99a5c